### PR TITLE
[cross-template-inject] Use linux-glibc-devel as real package name in kernel-headers build. JB#59595

### DIFF
--- a/cross-glibc-devel-inject.spec
+++ b/cross-glibc-devel-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname glibc-devel
+%define oldrealname glibc-devel
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/cross-glibc-headers-inject.spec
+++ b/cross-glibc-headers-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname glibc-headers
+%define oldrealname glibc-headers
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/cross-glibc-inject.spec
+++ b/cross-glibc-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname glibc
+%define oldrealname glibc
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/cross-kernel-headers-inject.spec
+++ b/cross-kernel-headers-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname kernel-headers
+%define oldrealname linux-glibc-devel
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/cross-libxcrypt-devel-inject.spec
+++ b/cross-libxcrypt-devel-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname libxcrypt-devel
+%define oldrealname libxcrypt-devel
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/cross-libxcrypt-inject.spec
+++ b/cross-libxcrypt-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname libxcrypt
+%define oldrealname libxcrypt
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/cross-template-inject.changes
+++ b/cross-template-inject.changes
@@ -1,3 +1,6 @@
+* Tue Jan 23 2024 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 1.0
+- Use linux-glibc-devel as real package name for in kernel-headers build. JB#59595
+
 * Sun Dec 17 2023 Matti Lehtimäki <matti.lehtimaki@jolla.com> - 1.0
 - Add cross packages for libxcrypt. JB#60722
 - Block 64bit targettype

--- a/cross-template-inject.spec
+++ b/cross-template-inject.spec
@@ -22,6 +22,7 @@
 #
 # The original package name
 %define oldname @PACKAGENAME@
+%define oldrealname @REALPACKAGENAME@
 #
 ### no changes needed below this line
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -34,13 +35,13 @@
 %define newname cross-%{oldname}-inject
 #
 # The version of the original package is read from its rpm db info
-%define newversion %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{version}' %oldname || echo '1.0')}
+%define newversion %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{version}' %oldrealname || echo '1.0')}
 #
 # The license of the original package is read from its rpm db info
-%define newlicense %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%%{license}' %oldname || echo 'UNKOWN')}
+%define newlicense %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%%{license}' %oldrealname || echo 'UNKOWN')}
 #
 # The summary of the original package
-%define newsummary %{expand:%(rpm --quiet -q %oldname && rpm -q --qf '%{summary} - special version ' %oldname || echo 'UNKNOWN.')}
+%define newsummary %{expand:%(rpm --quiet -q %oldrealname && rpm -q --qf '%{summary} - special version ' %oldrealname || echo 'UNKNOWN.')}
 #
 # New rpath to add to files on request
 %define newrpath "/opt/cross/%_target_platform/sys-root/lib:/opt/cross/%_target_platform/sys-root/usr/lib"
@@ -89,7 +90,7 @@ Source101:     precheckin.sh
 This is a meta-package providing %name.
 It is not intended to be used in a normal System!
 Original description:
-%{expand:%(rpm -q --qf '[%{description}]' %oldname)}
+%{expand:%(rpm -q --qf '[%{description}]' %oldrealname)}
 
 
 
@@ -100,7 +101,7 @@ Original description:
 %install
 set +x
 mkdir -p %buildroot
-rpm -ql %oldname > filestoinclude1
+rpm -ql %oldrealname > filestoinclude1
 %if %files_to_ignore
 for i in `cat %{_sourcedir}/files_to_ignore`; do
  echo "Ignoring file: $i"

--- a/precheckin.sh
+++ b/precheckin.sh
@@ -2,4 +2,9 @@
 for x in glibc glibc-devel glibc-headers kernel-headers libxcrypt libxcrypt-devel; do
 	sed "s/ExclusiveArch: none//g" cross-template-inject.spec > cross-$x-inject.spec
 	sed -i "s/@PACKAGENAME@/$x/g" cross-$x-inject.spec
+	if [ "$x" = "kernel-headers" ]; then
+		sed -i "s/@REALPACKAGENAME@/linux-glibc-devel/g" cross-$x-inject.spec
+	else
+		sed -i "s/@REALPACKAGENAME@/$x/g" cross-$x-inject.spec
+	fi
 done


### PR DESCRIPTION
Add support for alternative real package name to support renamed packages.